### PR TITLE
Added timeoutBeforeWaitForPageToLoad option for slow frameworks

### DIFF
--- a/src/commands/wait.for.page.to.load.js
+++ b/src/commands/wait.for.page.to.load.js
@@ -1,12 +1,9 @@
 /* global stepsConfig */
 
-module.exports = function waitForPageToLoad () {
+module.exports = async function waitForPageToLoad () {
     /**
      * Wait for page to get fully loaded
      */
-    return new Promise(function (resolve) {
-        setTimeout(() => {
-            return resolve(browser.waitUntil(stepsConfig.finishedLoadingConditions));
-        }, stepsConfig.timeoutBeforeWaitForPageToLoad);
-    });
+    await browser.pause(stepsConfig.timeoutBeforeWaitForPageToLoad);
+    return await browser.waitUntil(stepsConfig.finishedLoadingConditions);
 };

--- a/src/commands/wait.for.page.to.load.js
+++ b/src/commands/wait.for.page.to.load.js
@@ -3,7 +3,10 @@
 module.exports = function waitForPageToLoad () {
     /**
      * Wait for page to get fully loaded
-     * @param {callback} callback - A callback to run
      */
-    return browser.waitUntil(stepsConfig.finishedLoadingConditions);
+    return new Promise(function (resolve) {
+        setTimeout(() => {
+            return resolve(browser.waitUntil(stepsConfig.finishedLoadingConditions));
+        }, stepsConfig.timeoutBeforeWaitForPageToLoad);
+    });
 };

--- a/src/steps.conf.generator.js
+++ b/src/steps.conf.generator.js
@@ -18,6 +18,7 @@ const defaultIdGenerator = () => (new Date()).getTime();
 module.exports = function ({
     loaderSelectors = [], // <string>[] - array of xpath selectors, that will be used by finishedLoadingConditions.
     finishedLoadingConditions = defaultFinishedLoadingConditions, // <(loaderSelectors) => <boolean>>.
+    timeoutBeforeWaitForPageToLoad = 0, // <number> - time in milliseconds to wait before running waitForPageToLoad.
     pages = {}, // <{[key: string]: {[key: string]: <string>}}> - object, that contains "key" -> "Page object" pairs.
     defaultIdValue = '', // Default value of steps config Id.
     idGenerator = defaultIdGenerator, // <() => <string|number>> - function, that will return new generated id.
@@ -38,6 +39,7 @@ module.exports = function ({
     return {
         loaderSelectors,
         finishedLoadingConditions: finishedLoadingConditions.bind(this, loaderSelectors),
+        timeoutBeforeWaitForPageToLoad,
         pages,
         id: new Id(),
         objectsProcessor

--- a/test/steps.conf.js
+++ b/test/steps.conf.js
@@ -12,7 +12,12 @@ const pages = {
     values: require('./features/dictionary_objects/values')
 };
 
+// Time in milliseconds to wait before running waitForPageToLoad
+// could be used for the slow frameworks
+const timeoutBeforeWaitForPageToLoad = 0;
+
 module.exports = {
     loaderSelectors,
-    pages
+    pages,
+    timeoutBeforeWaitForPageToLoad
 };


### PR DESCRIPTION
**This pull request adds timeoutBeforeWaitForPageToLoad option for slow frameworks**

Fixes https://github.com/revjet-qa/wdio-cucumber-steps/issues/61